### PR TITLE
fix: antenna filter not handling protected notes

### DIFF
--- a/packages/backend/src/core/AntennaService.ts
+++ b/packages/backend/src/core/AntennaService.ts
@@ -145,7 +145,7 @@ export class AntennaService implements OnApplicationShutdown {
 				const relationship = await this.userEntityService.getRelation(userId, note.userId);
 				if (relationship.isFollowing) return true;
 			}
-			if (!note.visibleUserIds?.includes(userId) && !note.mentions?.includes(userId)) return false;
+			if (!note.visibleUserIds?.includes(userId)) return false;
 		}
 		return true;
 	}

--- a/packages/backend/src/core/AntennaService.ts
+++ b/packages/backend/src/core/AntennaService.ts
@@ -129,31 +129,30 @@ export class AntennaService implements OnApplicationShutdown {
 	// NOTE: フォローしているユーザーのノート、リストのユーザーのノート、グループのユーザーのノート指定はパフォーマンス上の理由で無効になっている
 
 	@bindThis
-	private async filter(me: MiUser | null, note: (MiNote | Packed<'Note'>)): Promise<boolean> {
+	private async filter(userId: MiUser['id'], note: (MiNote | Packed<'Note'>)): Promise<boolean> {
 		const [
 			userIdsWhoMeMuting,
 			userIdsWhoBlockingMe,
-		] = me ? await Promise.all([
-			this.cacheService.userMutingsCache.fetch(me.id),
-			this.cacheService.userBlockedCache.fetch(me.id),
-		]) : [new Set<string>(), new Set<string>()];
-		if (me && isUserRelated(note, userIdsWhoBlockingMe)) return false;
-		if (me && isUserRelated(note, userIdsWhoMeMuting)) return false;
+		] = await Promise.all([
+			this.cacheService.userMutingsCache.fetch(userId),
+			this.cacheService.userBlockedCache.fetch(userId),
+		]);
+		if (isUserRelated(note, userIdsWhoBlockingMe)) return false;
+		if (isUserRelated(note, userIdsWhoMeMuting)) return false;
 		if (['followers', 'specified'].includes(note.visibility)) {
-			if (me == null) return false;
-			if (me.id === note.userId) return true;
+			if (userId === note.userId) return true;
 			if (note.visibility === 'followers') {
-				const relationship = await this.userEntityService.getRelation(me.id, note.userId);
+				const relationship = await this.userEntityService.getRelation(userId, note.userId);
 				if (relationship.isFollowing) return true;
 			}
-			if (!note.visibleUserIds?.includes(me.id) && !note.mentions?.includes(me.id)) return false;
+			if (!note.visibleUserIds?.includes(userId) && !note.mentions?.includes(userId)) return false;
 		}
 		return true;
 	}
 
 	@bindThis
 	public async checkHitAntenna(antenna: MiAntenna, note: (MiNote | Packed<'Note'>), noteUser: { id: MiUser['id']; username: string; host: string | null; isBot: boolean; }): Promise<boolean> {
-		const result = await this.filter(antenna.user, note);
+		const result = await this.filter(antenna.userId, note);
 		if (!result) return false;
 
 		if (antenna.excludeBots && noteUser.isBot) return false;


### PR DESCRIPTION
<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
팔로워 전용/다이렉트 노트가 안테나에 잡히지 않는 문제를 해결하고, 동시에 다이렉트 노트에 멘션만 된 사용자는 안테나를 통해 노트 내용을 유추할 수 없게 변경했습니다.

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
