### PR TITLE
feat(role): add canIgnoreSensitiveWords policy

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -2149,6 +2149,7 @@ _role:
     gtlAvailable: "Can view the global timeline"
     ltlAvailable: "Can view the local timeline"
     canPublicNote: "Can send public notes"
+    canIgnoreSensitiveWords: "Ignore sensitive word restrictions"
     canScheduleNote: "Can schedule notes"
     scheduleNoteLimit: "Maximum number of scheduled notes"
     scheduleNoteMaxDays: "Maximum number of days that note can be scheduled"

--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -8301,6 +8301,10 @@ export interface Locale extends ILocale {
              */
             "canPublicNote": string;
             /**
+             * センシティブワードの制限を無視
+             */
+            "canIgnoreSensitiveWords": string;
+            /**
              * 予約投稿の許可
              */
             "canScheduleNote": string;

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -2144,6 +2144,7 @@ _role:
     gtlAvailable: "グローバルタイムラインの閲覧"
     ltlAvailable: "ローカルタイムラインの閲覧"
     canPublicNote: "パブリック投稿の許可"
+    canIgnoreSensitiveWords: "センシティブワードの制限を無視"
     canScheduleNote: "予約投稿の許可"
     scheduleNoteLimit: "予約投稿の最大数"
     scheduleNoteMaxDays: "予約投稿の最大日数"

--- a/locales/ko-KR.yml
+++ b/locales/ko-KR.yml
@@ -2131,6 +2131,7 @@ _role:
     gtlAvailable: "글로벌 타임라인 보이기"
     ltlAvailable: "로컬 타임라인 보이기"
     canPublicNote: "공개 노트 허용"
+    canIgnoreSensitiveWords: "민감한 단어 제한 무시"
     canScheduleNote: "노트 예약 허용"
     scheduleNoteLimit: "노트 예약 한도"
     scheduleNoteMaxDays: "노트 예약 최대 일수"

--- a/packages/backend/src/core/NoteCreateService.ts
+++ b/packages/backend/src/core/NoteCreateService.ts
@@ -258,7 +258,7 @@ export class NoteCreateService implements OnApplicationShutdown {
 
 		if (data.visibility === 'public' && data.channel == null) {
 			const sensitiveWords = meta.sensitiveWords;
-			if (this.utilityService.isKeyWordIncluded(data.cw ?? this.utilityService.concatNoteContentsForKeyWordCheck({ text: data.text, pollChoices: data.poll?.choices }), sensitiveWords)) {
+			if (!policies.canIgnoreSensitiveWords && this.utilityService.isKeyWordIncluded(data.cw ?? this.utilityService.concatNoteContentsForKeyWordCheck({ text: data.text, pollChoices: data.poll?.choices }), sensitiveWords)) {
 				data.visibility = 'home';
 				this.logger.warn('Visibility changed to home because sensitive words are included', { userId: user.id, note: data });
 			} else if (!policies.canPublicNote) {

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -40,6 +40,7 @@ export type RolePolicies = {
 	gtlAvailable: boolean;
 	ltlAvailable: boolean;
 	canPublicNote: boolean;
+	canIgnoreSensitiveWords: boolean;
 	canScheduleNote: boolean;
 	scheduleNoteLimit: number;
 	scheduleNoteMaxDays: number;
@@ -93,6 +94,7 @@ export const DEFAULT_POLICIES: RolePolicies = {
 	gtlAvailable: true,
 	ltlAvailable: true,
 	canPublicNote: true,
+	canIgnoreSensitiveWords: false,
 	canScheduleNote: true,
 	scheduleNoteLimit: 10,
 	scheduleNoteMaxDays: 365,
@@ -449,6 +451,7 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			gtlAvailable: calc('gtlAvailable', vs => vs.some(v => v === true)),
 			ltlAvailable: calc('ltlAvailable', vs => vs.some(v => v === true)),
 			canPublicNote: calc('canPublicNote', vs => vs.some(v => v === true)),
+			canIgnoreSensitiveWords: calc('canIgnoreSensitiveWords', vs => vs.some(v => v === true)),
 			canScheduleNote: calc('canScheduleNote', vs => vs.some(v => v === true)),
 			scheduleNoteLimit: calc('scheduleNoteLimit', vs => Math.max(...vs)),
 			scheduleNoteMaxDays: calc('scheduleNoteMaxDays', vs => Math.max(...vs)),

--- a/packages/backend/src/models/json-schema/role.ts
+++ b/packages/backend/src/models/json-schema/role.ts
@@ -180,6 +180,10 @@ export const packedRolePoliciesSchema = {
 			type: 'boolean',
 			optional: false, nullable: false,
 		},
+		canIgnoreSensitiveWords: {
+			type: 'boolean',
+			optional: false, nullable: false,
+		},
 		canScheduleNote: {
 			type: 'boolean',
 			optional: false, nullable: false,

--- a/packages/frontend-shared/js/const.ts
+++ b/packages/frontend-shared/js/const.ts
@@ -84,6 +84,7 @@ export const ROLE_POLICIES = [
 	'gtlAvailable',
 	'ltlAvailable',
 	'canPublicNote',
+	'canIgnoreSensitiveWords',
 	'canScheduleNote',
 	'scheduleNoteLimit',
 	'scheduleNoteMaxDays',

--- a/packages/frontend/src/pages/admin/roles.editor.vue
+++ b/packages/frontend/src/pages/admin/roles.editor.vue
@@ -170,6 +170,26 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</div>
 			</MkFolder>
 
+			<MkFolder v-if="matchQuery([i18n.ts._role._options.canIgnoreSensitiveWords, 'canIgnoreSensitiveWords'])">
+				<template #label>{{ i18n.ts._role._options.canIgnoreSensitiveWords }}</template>
+				<template #suffix>
+					<span v-if="role.policies.canIgnoreSensitiveWords.useDefault" :class="$style.useDefaultLabel">{{ i18n.ts._role.useBaseValue }}</span>
+					<span v-else>{{ role.policies.canIgnoreSensitiveWords.value ? i18n.ts.yes : i18n.ts.no }}</span>
+					<span :class="$style.priorityIndicator"><i :class="getPriorityIcon(role.policies.canIgnoreSensitiveWords)"></i></span>
+				</template>
+				<div class="_gaps">
+					<MkSwitch v-model="role.policies.canIgnoreSensitiveWords.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts._role.useBaseValue }}</template>
+					</MkSwitch>
+					<MkSwitch v-model="role.policies.canIgnoreSensitiveWords.value" :disabled="role.policies.canIgnoreSensitiveWords.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts.enable }}</template>
+					</MkSwitch>
+					<MkRange v-model="role.policies.canIgnoreSensitiveWords.priority" :min="0" :max="2" :step="1" easing :textConverter="(v) => v === 0 ? i18n.ts._role._priority.low : v === 1 ? i18n.ts._role._priority.middle : v === 2 ? i18n.ts._role._priority.high : ''">
+						<template #label>{{ i18n.ts._role.priority }}</template>
+					</MkRange>
+				</div>
+			</MkFolder>
+
 			<MkFolder v-if="matchQuery([i18n.ts._role._options.chatAvailability, 'chatAvailability'])">
 				<template #label>{{ i18n.ts._role._options.chatAvailability }}</template>
 				<template #suffix>

--- a/packages/misskey-js/src/autogen/types.ts
+++ b/packages/misskey-js/src/autogen/types.ts
@@ -10756,6 +10756,7 @@ export type components = {
             gtlAvailable: boolean;
             ltlAvailable: boolean;
             canPublicNote: boolean;
+            canIgnoreSensitiveWords: boolean;
             canScheduleNote: boolean;
             scheduleNoteLimit: number;
             scheduleNoteMaxDays: number;
@@ -17793,7 +17794,7 @@ export interface operations {
                     policies: {
                         id?: string | null;
                         /** @enum {string} */
-                        policy: 'gtlAvailable' | 'ltlAvailable' | 'canPublicNote' | 'canScheduleNote' | 'scheduleNoteLimit' | 'scheduleNoteMaxDays' | 'canInitiateConversation' | 'canCreateContent' | 'canUpdateContent' | 'canDeleteContent' | 'canPurgeAccount' | 'canUpdateAvatar' | 'canUpdateBanner' | 'mentionLimit' | 'canInvite' | 'inviteLimit' | 'inviteLimitCycle' | 'inviteExpirationTime' | 'canManageCustomEmojis' | 'canManageAvatarDecorations' | 'canSearchNotes' | 'canUseTranslator' | 'canUseDriveFileInSoundSettings' | 'canUseReaction' | 'canHideAds' | 'driveCapacityMb' | 'maxFileSizeMb' | 'alwaysMarkNsfw' | 'canUpdateBioMedia' | 'skipNsfwDetection' | 'pinLimit' | 'antennaLimit' | 'antennaNotesLimit' | 'wordMuteLimit' | 'webhookLimit' | 'clipLimit' | 'noteEachClipsLimit' | 'userListLimit' | 'userEachUserListsLimit' | 'rateLimitFactor' | 'avatarDecorationLimit' | 'canUseAccountRemoval' | 'canImportAntennas' | 'canImportBlocking' | 'canImportFollowing' | 'canImportMuting' | 'canImportUserLists' | 'mutualLinkSectionLimit' | 'mutualLinkLimit' | 'chatAvailability';
+                        policy: 'gtlAvailable' | 'ltlAvailable' | 'canPublicNote' | 'canIgnoreSensitiveWords' | 'canScheduleNote' | 'scheduleNoteLimit' | 'scheduleNoteMaxDays' | 'canInitiateConversation' | 'canCreateContent' | 'canUpdateContent' | 'canDeleteContent' | 'canPurgeAccount' | 'canUpdateAvatar' | 'canUpdateBanner' | 'mentionLimit' | 'canInvite' | 'inviteLimit' | 'inviteLimitCycle' | 'inviteExpirationTime' | 'canManageCustomEmojis' | 'canManageAvatarDecorations' | 'canSearchNotes' | 'canUseTranslator' | 'canUseDriveFileInSoundSettings' | 'canUseReaction' | 'canHideAds' | 'driveCapacityMb' | 'maxFileSizeMb' | 'alwaysMarkNsfw' | 'canUpdateBioMedia' | 'skipNsfwDetection' | 'pinLimit' | 'antennaLimit' | 'antennaNotesLimit' | 'wordMuteLimit' | 'webhookLimit' | 'clipLimit' | 'noteEachClipsLimit' | 'userListLimit' | 'userEachUserListsLimit' | 'rateLimitFactor' | 'avatarDecorationLimit' | 'canUseAccountRemoval' | 'canImportAntennas' | 'canImportBlocking' | 'canImportFollowing' | 'canImportMuting' | 'canImportUserLists' | 'mutualLinkSectionLimit' | 'mutualLinkLimit' | 'chatAvailability';
                         /**
                          * @default set
                          * @enum {string}


### PR DESCRIPTION
Closes #55

민감한 단어(sensitiveWords)가 포함된 공개 노트가 home으로 강등되는 것을 롤 정책으로 우회할 수 있게 합니다.

- `canIgnoreSensitiveWords` 롤 정책 추가 (기본값: false)
- 정책이 켜진 유저는 민감한 단어가 포함돼도 public 가시성 유지
- 롤 에디터 UI 및 ko/ja/en 로케일 추가