### PR TITLE
feat(note): preserve replies of deleted notes with tombstones

### DIFF
--- a/packages/backend/migration/1784348915964-noteDeletedAt.js
+++ b/packages/backend/migration/1784348915964-noteDeletedAt.js
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export class noteDeletedAt1784348915964 {
+	name = 'noteDeletedAt1784348915964'
+
+	async up(queryRunner) {
+		await queryRunner.query(`ALTER TABLE "note" ADD "deletedAt" TIMESTAMP WITH TIME ZONE`);
+	}
+
+	async down(queryRunner) {
+		await queryRunner.query(`DELETE FROM "note" WHERE "deletedAt" IS NOT NULL`);
+		await queryRunner.query(`ALTER TABLE "note" DROP COLUMN "deletedAt"`);
+	}
+}

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -7,7 +7,7 @@ import { Brackets, In, IsNull, Not } from 'typeorm';
 import { Injectable, Inject } from '@nestjs/common';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import type { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
-import type { InstancesRepository, MiMeta, NotesRepository, UsersRepository } from '@/models/_.js';
+import type { ClipNotesRepository, InstancesRepository, MiMeta, NoteFavoritesRepository, NoteReactionsRepository, NotesRepository, PollsRepository, PollVotesRepository, UserNotePiningsRepository, UsersRepository } from '@/models/_.js';
 import { RelayService } from '@/core/RelayService.js';
 import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
@@ -42,6 +42,24 @@ export class NoteDeleteService {
 		@Inject(DI.instancesRepository)
 		private instancesRepository: InstancesRepository,
 
+		@Inject(DI.pollsRepository)
+		private pollsRepository: PollsRepository,
+
+		@Inject(DI.pollVotesRepository)
+		private pollVotesRepository: PollVotesRepository,
+
+		@Inject(DI.noteReactionsRepository)
+		private noteReactionsRepository: NoteReactionsRepository,
+
+		@Inject(DI.noteFavoritesRepository)
+		private noteFavoritesRepository: NoteFavoritesRepository,
+
+		@Inject(DI.clipNotesRepository)
+		private clipNotesRepository: ClipNotesRepository,
+
+		@Inject(DI.userNotePiningsRepository)
+		private userNotePiningsRepository: UserNotePiningsRepository,
+
 		private userEntityService: UserEntityService,
 		private globalEventService: GlobalEventService,
 		private relayService: RelayService,
@@ -61,8 +79,11 @@ export class NoteDeleteService {
 	 * @param note 投稿
 	 */
 	async delete(user: { id: MiUser['id']; uri: MiUser['uri']; host: MiUser['host']; isBot: MiUser['isBot']; }, note: MiNote, quiet = false, deleter?: MiUser) {
+		if (note.deletedAt != null) return;
+
 		const deletedAt = new Date();
 		const cascadingNotes = await this.findCascadingNotes(note);
+		const hasChildrenNotes = await this.hasChildrenNotes(note);
 
 		if (note.replyId) {
 			await this.notesRepository.decrement({ id: note.replyId }, 'repliesCount', 1);
@@ -92,12 +113,14 @@ export class NoteDeleteService {
 			}
 
 			// also deliver delete activity to cascaded notes
-			const federatedLocalCascadingNotes = (cascadingNotes).filter(note => !note.localOnly && note.userHost == null); // filter out local-only notes
-			for (const cascadingNote of federatedLocalCascadingNotes) {
-				if (!cascadingNote.user) continue;
-				if (!this.userEntityService.isLocalUser(cascadingNote.user)) continue;
-				const content = this.apRendererService.addContext(this.apRendererService.renderDelete(this.apRendererService.renderTombstone(`${this.config.url}/notes/${cascadingNote.id}`), cascadingNote.user));
-				this.deliverToConcerned(cascadingNote.user, cascadingNote, content);
+			if (!hasChildrenNotes) {
+				const federatedLocalCascadingNotes = (cascadingNotes).filter(note => !note.localOnly && note.userHost == null); // filter out local-only notes
+				for (const cascadingNote of federatedLocalCascadingNotes) {
+					if (!cascadingNote.user) continue;
+					if (!this.userEntityService.isLocalUser(cascadingNote.user)) continue;
+					const content = this.apRendererService.addContext(this.apRendererService.renderDelete(this.apRendererService.renderTombstone(`${this.config.url}/notes/${cascadingNote.id}`), cascadingNote.user));
+					this.deliverToConcerned(cascadingNote.user, cascadingNote, content);
+				}
 			}
 			//#endregion
 
@@ -118,15 +141,60 @@ export class NoteDeleteService {
 			}
 		}
 
-		for (const cascadingNote of cascadingNotes) {
-			this.searchService.unindexNote(cascadingNote);
+		if (!hasChildrenNotes) {
+			for (const cascadingNote of cascadingNotes) {
+				this.searchService.unindexNote(cascadingNote);
+			}
 		}
 		this.searchService.unindexNote(note);
 
-		await this.notesRepository.delete({
-			id: note.id,
-			userId: user.id,
-		});
+		if (hasChildrenNotes) {
+			// 返信や引用が存在する場合は、スレッド構造を保持するために内容を消去したノートを残す
+			await this.notesRepository.update({
+				id: note.id,
+				userId: user.id,
+			}, {
+				deletedAt: deletedAt,
+				text: null,
+				cw: null,
+				name: null,
+				url: null,
+				renoteId: null,
+				fileIds: [],
+				attachedFileTypes: [],
+				mentions: [],
+				mentionedRemoteUsers: '[]',
+				emojis: [],
+				tags: [],
+				hasPoll: false,
+				reactions: {},
+				reactionAndUserPairCache: [],
+			});
+
+			// 従来はカスケード削除されていた関連レコードを掃除する
+			await Promise.all([
+				this.pollsRepository.delete({ noteId: note.id }),
+				this.pollVotesRepository.delete({ noteId: note.id }),
+				this.noteReactionsRepository.delete({ noteId: note.id }),
+				this.noteFavoritesRepository.delete({ noteId: note.id }),
+				this.clipNotesRepository.delete({ noteId: note.id }),
+				this.userNotePiningsRepository.delete({ noteId: note.id }),
+			]);
+
+			// 純粋なリノートもカスケード削除されなくなるため明示的に削除する
+			await this.notesRepository.createQueryBuilder()
+				.delete()
+				.where('"renoteId" = :noteId', { noteId: note.id })
+				.andWhere('text IS NULL')
+				.andWhere('"fileIds" = \'{}\'')
+				.andWhere('"hasPoll" = FALSE')
+				.execute();
+		} else {
+			await this.notesRepository.delete({
+				id: note.id,
+				userId: user.id,
+			});
+		}
 
 		if (deleter && (note.userId !== deleter.id)) {
 			const user = await this.usersRepository.findOneByOrFail({ id: note.userId });
@@ -138,6 +206,21 @@ export class NoteDeleteService {
 				note: note,
 			});
 		}
+	}
+
+	@bindThis
+	private async hasChildrenNotes(note: MiNote): Promise<boolean> {
+		return await this.notesRepository.createQueryBuilder('note')
+			.where('note.replyId = :noteId', { noteId: note.id })
+			.orWhere(new Brackets(qb => {
+				qb.where('note.renoteId = :noteId', { noteId: note.id })
+					.andWhere(new Brackets(qb => {
+						qb.where('note.text IS NOT NULL')
+							.orWhere('note.fileIds != \'{}\'')
+							.orWhere('note.hasPoll = TRUE');
+					}));
+			}))
+			.getExists();
 	}
 
 	@bindThis

--- a/packages/backend/src/core/WebhookTestService.ts
+++ b/packages/backend/src/core/WebhookTestService.ts
@@ -72,6 +72,7 @@ function generateDummyUser(override?: Partial<MiUser>): MiUser {
 function generateDummyNote(override?: Partial<MiNote>): MiNote {
 	return {
 		id: 'dummy-note-1',
+		deletedAt: null,
 		replyId: null,
 		reply: null,
 		renoteId: null,

--- a/packages/backend/src/core/entities/NoteEntityService.ts
+++ b/packages/backend/src/core/entities/NoteEntityService.ts
@@ -428,6 +428,7 @@ export class NoteEntityService implements OnModuleInit {
 			skipLanguageCheck?: boolean;
 			withReactionAndUserPairCache?: boolean;
 			viewerDimension?: number | null;
+			allowDeleted?: boolean;
 			_hint_?: {
 				bufferedReactions: Map<MiNote['id'], { deltas: Record<string, number>; pairs: ([MiUser['id'], string])[] }> | null;
 				myReactions: Map<MiNote['id'], string | null>;
@@ -440,10 +441,15 @@ export class NoteEntityService implements OnModuleInit {
 			detail: true,
 			skipHide: false,
 			withReactionAndUserPairCache: false,
+			allowDeleted: false,
 		}, options);
 
 		const meId = me ? me.id : null;
 		const note = typeof src === 'object' ? src : await this.noteLoader.load(src);
+
+		if (note.deletedAt != null && !opts.allowDeleted) {
+			throw new IdentifiableError('c725abcd-0d3a-4bfe-9b5f-7ac21f420b8f', 'Note is deleted.');
+		}
 
 		if (!opts.skipLanguageCheck && meId && !(await this.isLanguageVisibleToMe(note, meId))) {
 			throw new IdentifiableError('ab3e8c80-9d5b-4fb8-9ee0-089ed96d07e0', 'Note language is not visible for you.');
@@ -491,6 +497,7 @@ export class NoteEntityService implements OnModuleInit {
 		const packed: Packed<'Note'> = await awaitAll({
 			id: note.id,
 			createdAt: this.idService.parse(note.id).date.toISOString(),
+			deletedAt: note.deletedAt ? note.deletedAt.toISOString() : undefined,
 			userId: note.userId,
 			user: packedUsers?.get(note.userId) ?? await this.userEntityService.pack(note.user ?? note.userId, me),
 			text: text,
@@ -535,6 +542,7 @@ export class NoteEntityService implements OnModuleInit {
 					skipLanguageCheck: true,
 					viewerDimension: null,
 					withReactionAndUserPairCache: opts.withReactionAndUserPairCache,
+					allowDeleted: true,
 					_hint_: options?._hint_,
 				}) : undefined,
 
@@ -544,6 +552,7 @@ export class NoteEntityService implements OnModuleInit {
 					skipLanguageCheck: true,
 					viewerDimension: null,
 					withReactionAndUserPairCache: opts.withReactionAndUserPairCache,
+					allowDeleted: true,
 					_hint_: options?._hint_,
 				}) : undefined,
 
@@ -583,6 +592,7 @@ export class NoteEntityService implements OnModuleInit {
 			detail?: boolean;
 			skipHide?: boolean;
 			viewerDimension?: number | null;
+			allowDeleted?: boolean;
 		},
 	) : Promise<Packed<'Note'>[]> {
 		if (notes.length === 0) return [];

--- a/packages/backend/src/models/Note.ts
+++ b/packages/backend/src/models/Note.ts
@@ -27,6 +27,12 @@ export class MiNote {
 	})
 	public createdAt: Date;
 
+	@Column('timestamp with time zone', {
+		nullable: true,
+		comment: 'The deleted date of the Note.',
+	})
+	public deletedAt: Date | null;
+
 	@Index()
 	@Column({
 		...id(),

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -549,6 +549,7 @@ export class ActivityPubServerService {
 					.orWhere('note.visibility = \'home\'');
 			}))
 			.andWhere('note.localOnly = FALSE')
+			.andWhere('note.deletedAt IS NULL')
 			.limit(limit)
 			.getMany();
 	}
@@ -649,6 +650,7 @@ export class ActivityPubServerService {
 
 			const note = await this.notesRepository.findOneBy({
 				id: request.params.note,
+				deletedAt: IsNull(),
 				visibility: In(['public', 'home']),
 				localOnly: false,
 			});
@@ -685,6 +687,7 @@ export class ActivityPubServerService {
 			const note = await this.notesRepository.findOneBy({
 				id: request.params.note,
 				userHost: IsNull(),
+				deletedAt: IsNull(),
 				visibility: In(['public', 'home']),
 				localOnly: false,
 			});

--- a/packages/backend/src/server/api/GetterService.ts
+++ b/packages/backend/src/server/api/GetterService.ts
@@ -29,10 +29,10 @@ export class GetterService {
 	 * Get note for API processing
 	 */
 	@bindThis
-	public async getNote(noteId: MiNote['id']) {
+	public async getNote(noteId: MiNote['id'], includeDeleted = false) {
 		const note = await this.notesRepository.findOneBy({ id: noteId });
 
-		if (note == null) {
+		if (note == null || (note.deletedAt != null && !includeDeleted)) {
 			throw new IdentifiableError('9725d0ce-ba28-4dde-95a7-2cbb2c15de24', 'No such note.');
 		}
 
@@ -40,10 +40,10 @@ export class GetterService {
 	}
 
 	@bindThis
-	public async getNoteWithUser(noteId: MiNote['id']) {
+	public async getNoteWithUser(noteId: MiNote['id'], includeDeleted = false) {
 		const note = await this.notesRepository.findOne({ where: { id: noteId }, relations: ['user'] });
 
-		if (note == null) {
+		if (note == null || (note.deletedAt != null && !includeDeleted)) {
 			throw new IdentifiableError('9725d0ce-ba28-4dde-95a7-2cbb2c15de24', 'No such note.');
 		}
 

--- a/packages/backend/src/server/api/endpoints/notes/children.ts
+++ b/packages/backend/src/server/api/endpoints/notes/children.ts
@@ -78,7 +78,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			const notes = await query.limit(ps.limit).getMany();
 
-			return await this.noteEntityService.packMany(notes, me);
+			return await this.noteEntityService.packMany(notes, me, { allowDeleted: true });
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/conversation.ts
+++ b/packages/backend/src/server/api/endpoints/notes/conversation.ts
@@ -59,7 +59,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private cacheService: CacheService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
-			const note = await this.getterService.getNote(ps.noteId).catch(err => {
+			const note = await this.getterService.getNote(ps.noteId, true).catch(err => {
 				if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 				throw err;
 			});
@@ -97,7 +97,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				await get(note.replyId);
 			}
 
-			return await this.noteEntityService.packMany(conversation, me);
+			return await this.noteEntityService.packMany(conversation, me, { allowDeleted: true });
 		});
 	}
 }

--- a/packages/backend/src/server/api/endpoints/notes/show.ts
+++ b/packages/backend/src/server/api/endpoints/notes/show.ts
@@ -50,7 +50,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private getterService: GetterService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
-			const note = await this.getterService.getNoteWithUser(ps.noteId).catch(err => {
+			const note = await this.getterService.getNoteWithUser(ps.noteId, true).catch(err => {
 				if (err.id === '9725d0ce-ba28-4dde-95a7-2cbb2c15de24') throw new ApiError(meta.errors.noSuchNote);
 				throw err;
 			});
@@ -63,6 +63,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				detail: true,
 				skipLanguageCheck: true,
 				viewerDimension: null,
+				allowDeleted: true,
 			});
 		});
 	}

--- a/packages/backend/src/server/web/ClientServerService.ts
+++ b/packages/backend/src/server/web/ClientServerService.ts
@@ -645,6 +645,7 @@ export class ClientServerService {
 			const note = await this.notesRepository.findOne({
 				where: {
 					id: request.params.note,
+					deletedAt: IsNull(),
 					visibility: In(['public', 'home']),
 				},
 				relations: ['user'],
@@ -684,6 +685,7 @@ export class ClientServerService {
 		fastify.get<{ Params: { note: string; } }>('/notes/:note.json', async (request, reply) => {
 			const note = await this.notesRepository.findOneBy({
 				id: request.params.note,
+				deletedAt: IsNull(),
 				visibility: In(['public', 'home']),
 			});
 

--- a/packages/backend/test/unit/NoteCreateService.ts
+++ b/packages/backend/test/unit/NoteCreateService.ts
@@ -26,6 +26,7 @@ describe('NoteCreateService', () => {
 		const base: MiNote = {
 			id: 'some-note-id',
 			createdAt: new Date(2016, 11, 28, 22, 49, 51),
+			deletedAt: null,
 			replyId: null,
 			reply: null,
 			renoteId: null,

--- a/packages/backend/test/unit/misc/is-renote.ts
+++ b/packages/backend/test/unit/misc/is-renote.ts
@@ -9,6 +9,7 @@ import { MiNote } from '@/models/Note.js';
 const base: MiNote = {
 	id: 'some-note-id',
 	createdAt: new Date(2016, 11, 28, 22, 49, 51),
+	deletedAt: null,
 	replyId: null,
 	reply: null,
 	renoteId: null,

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,6 +64,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				<div v-show="appearNote.cw == null || showContent" :class="[{ [$style.contentCollapsed]: collapsed }]">
 					<div :class="$style.text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
+						<span v-if="appearNote.deletedAt" style="opacity: 0.5">({{ i18n.ts.deletedNote }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 						<Mfm
 							v-if="appearNote.text"

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -87,6 +87,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 			</p>
 			<div v-show="appearNote.cw == null || showContent">
 				<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
+				<span v-if="appearNote.deletedAt" style="opacity: 0.5">({{ i18n.ts.deletedNote }})</span>
 				<MkA v-if="appearNote.replyId" :class="$style.noteReplyTarget" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
 				<Mfm
 					v-if="appearNote.text"
@@ -125,7 +126,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				</MkA>
 			</div>
 			<MkReactionsViewer v-if="appearNote.reactionAcceptance !== 'likeOnly'" ref="reactionsViewer" style="margin-top: 6px;" :note="appearNote"/>
-			<button class="_button" :class="$style.noteFooterButton" @click="reply()">
+			<button class="_button" :class="$style.noteFooterButton" :disabled="appearNote.deletedAt != null" @click="reply()">
 				<i class="ti ti-arrow-back-up"></i>
 				<p v-if="prefer.s.showRepliesCount && appearNote.repliesCount > 0" :class="$style.noteFooterButtonCount">{{ number(appearNote.repliesCount) }}</p>
 			</button>
@@ -134,6 +135,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 				ref="renoteButton"
 				class="_button"
 				:class="$style.noteFooterButton"
+				:disabled="appearNote.deletedAt != null"
 				@mousedown.prevent="renote()"
 			>
 				<i class="ti ti-repeat"></i>
@@ -142,20 +144,20 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<button v-else class="_button" :class="$style.noteFooterButton" disabled>
 				<i class="ti ti-ban"></i>
 			</button>
-			<button ref="reactButton" :class="$style.noteFooterButton" class="_button" @click="toggleReact()">
+			<button ref="reactButton" :class="$style.noteFooterButton" class="_button" :disabled="appearNote.deletedAt != null" @click="toggleReact()">
 				<i v-if=" (appearNote.reactionAcceptance === 'likeOnly' || !$i?.policies.canUseReaction) && appearNote.myReaction != null " class="ti-filled ti-filled-heart" style="color: var(--MI_THEME-love);"></i>
 				<i v-else-if="appearNote.myReaction != null " class="ti ti-minus" style="color: var(--MI_THEME-accent);"></i>
 				<i v-else-if="appearNote.reactionAcceptance === 'likeOnly' || $i && !$i.policies.canUseReaction" class="ti ti-heart"></i>
 				<i v-else class="ti ti-plus"></i>
 				<p v-if="(appearNote.reactionAcceptance === 'likeOnly' || prefer.s.showReactionsCount) && appearNote.reactionCount > 0" :class="$style.noteFooterButtonCount">{{ number(appearNote.reactionCount) }}</p>
 			</button>
-			<button v-if="prefer.s.showTranslateButtonInNoteFooter && $i?.policies.canUseTranslator && instance.translatorAvailable" class="_button" :class="$style.noteFooterButton" @mousedown.prevent="translate()">
+			<button v-if="prefer.s.showTranslateButtonInNoteFooter && $i?.policies.canUseTranslator && instance.translatorAvailable" class="_button" :class="$style.noteFooterButton" :disabled="appearNote.deletedAt != null" @mousedown.prevent="translate()">
 				<i class="ti ti-language-hiragana"></i>
 			</button>
-			<button v-if="prefer.s.showClipButtonInNoteFooter" ref="clipButton" class="_button" :class="$style.noteFooterButton" @mousedown.prevent="clip()">
+			<button v-if="prefer.s.showClipButtonInNoteFooter" ref="clipButton" class="_button" :class="$style.noteFooterButton" :disabled="appearNote.deletedAt != null" @mousedown.prevent="clip()">
 				<i class="ti ti-paperclip"></i>
 			</button>
-			<button ref="menuButton" class="_button" :class="$style.noteFooterButton" @mousedown.prevent="showMenu()">
+			<button ref="menuButton" class="_button" :class="$style.noteFooterButton" :disabled="appearNote.deletedAt != null" @mousedown.prevent="showMenu()">
 				<i class="ti ti-dots"></i>
 			</button>
 		</footer>


### PR DESCRIPTION
Resolves #74

## 문제

`note.replyId`/`renoteId` FK가 `ON DELETE CASCADE`라서 노트를 삭제하면 답글·인용 서브트리 전체가 DB에서 함께 삭제됨. 답글 작성자 본인조차 자기 노트를 확인하거나 삭제할 수 없었음.

## 해결 방식 (톰스톤)

- `note.deletedAt` 컬럼 추가 (마이그레이션 `1784348915964-noteDeletedAt`)
- **답글/인용이 달린 노트만** 하드 삭제 대신 내용을 소거(text/cw/파일/멘션/태그/투표/리액션)하고 `deletedAt`을 기록한 톰스톤으로 남김. 자식이 없으면 기존대로 하드 삭제라 DB 부담 없음
- 톰스톤 시 기존 카스케이드가 지우던 연관 레코드(poll, poll_vote, note_reaction, note_favorite, clip_note, user_note_pining)와 순수 리노트를 명시적으로 삭제. AP Delete(Tombstone) 배송과 검색 언인덱스는 기존과 동일

## 노출 제어

- `NoteEntityService.pack`이 기본적으로 삭제된 노트에서 throw → 타임라인·검색·알림·즐겨찾기 등 모든 목록에서 자동 제외 (packMany의 기존 allSettled 필터가 조용히 드롭)
- `notes/show` / `notes/children` / `notes/conversation`과 reply/renote 임베드만 `allowDeleted`로 옵트인 → 스레드 뷰에서 "삭제된 노트" 플레이스홀더로 표시되고 상하위 노트는 정상 표시
- `GetterService.getNote`가 기본적으로 `NO_SUCH_NOTE`를 던지므로 삭제된 노트에 대한 답글 작성·리노트·리액션 등 상호작용은 차단 (단, 연합으로 들어오는 원격 답글은 기존처럼 스레드에 붙음)
- AP `/notes/:id`·outbox·SSR HTML 라우트에서도 톰스톤 제외

## 프론트엔드

- packed `Note.deletedAt`은 스키마·misskey-js 타입에 이미 존재하던 필드라 autogen 변경 없음. `MkSubNoteContent`의 기존 `(deletedNote)` 플레이스홀더가 그대로 작동
- MkNote/MkNoteDetailed 본문에 플레이스홀더 추가, 상세 페이지의 액션 버튼(답글/리노트/리액션/번역/클립/메뉴) 비활성화
- 신규 로케일 키 없음 (`deletedNote` 재사용)

## 비고

- 이 변경 이전에 이미 카스케이드로 삭제된 스레드는 소급 복구되지 않음 (이슈에서 언급된 연결고리 단절 케이스)
- 검증: backend typecheck 통과, 변경 파일 eslint 0 error, `test/unit/misc/is-renote.ts` 7/7 통과. frontend vue-tsc 오류는 전부 기존 베이스라인 노이즈로 본 변경과 무관
