### PR TITLE
fix(frontend): prevent leaked tooltip popups from running rAF loops forever

### DIFF
--- a/packages/frontend/src/components/MkSkebStatusPopup.vue
+++ b/packages/frontend/src/components/MkSkebStatusPopup.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts" setup>
-import { nextTick, onMounted, onUnmounted, shallowRef } from 'vue';
+import { nextTick, onMounted, onUnmounted, shallowRef, watch } from 'vue';
 import * as Misskey from 'misskey-js';
 import * as os from '@/os.js';
 import { i18n } from '@/i18n.js';
@@ -66,23 +66,43 @@ function setPosition() {
 	el.value.style.top = data.top + 'px';
 }
 
-let loopHandler;
+let loopHandler: number | undefined;
+let unmounted = false;
+
+// 位置追従ループは表示中のみ回す(非表示のままマウントされ続けた場合やアンマウント後にループが残るとCPUを食い続けるため)
+function startLoop() {
+	if (unmounted || loopHandler != null) return;
+
+	const loop = () => {
+		setPosition();
+		loopHandler = window.requestAnimationFrame(loop);
+	};
+
+	loop();
+}
+
+function stopLoop() {
+	if (loopHandler != null) {
+		window.cancelAnimationFrame(loopHandler);
+		loopHandler = undefined;
+	}
+}
+
+watch(() => props.showing, (showing) => {
+	if (showing) startLoop();
+	else stopLoop();
+});
 
 onMounted(() => {
 	nextTick(() => {
 		setPosition();
-
-		const loop = () => {
-			setPosition();
-			loopHandler = window.requestAnimationFrame(loop);
-		};
-
-		loop();
+		if (props.showing) startLoop();
 	});
 });
 
 onUnmounted(() => {
-	window.cancelAnimationFrame(loopHandler);
+	unmounted = true;
+	stopLoop();
 });
 </script>
 

--- a/packages/frontend/src/components/MkTooltip.vue
+++ b/packages/frontend/src/components/MkTooltip.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 </template>
 
 <script lang="ts" setup>
-import { nextTick, onMounted, onUnmounted, useTemplateRef } from 'vue';
+import { nextTick, onMounted, onUnmounted, useTemplateRef, watch } from 'vue';
 import * as os from '@/os.js';
 import { calcPopupPosition } from '@/utility/popup-position.js';
 import { prefer } from '@/preferences.js';
@@ -71,23 +71,43 @@ function setPosition() {
 	el.value.style.top = data.top + 'px';
 }
 
-let loopHandler;
+let loopHandler: number | undefined;
+let unmounted = false;
+
+// 位置追従ループは表示中のみ回す(非表示のままマウントされ続けた場合やアンマウント後にループが残るとCPUを食い続けるため)
+function startLoop() {
+	if (unmounted || loopHandler != null) return;
+
+	const loop = () => {
+		setPosition();
+		loopHandler = window.requestAnimationFrame(loop);
+	};
+
+	loop();
+}
+
+function stopLoop() {
+	if (loopHandler != null) {
+		window.cancelAnimationFrame(loopHandler);
+		loopHandler = undefined;
+	}
+}
+
+watch(() => props.showing, (showing) => {
+	if (showing) startLoop();
+	else stopLoop();
+});
 
 onMounted(() => {
 	nextTick(() => {
 		setPosition();
-
-		const loop = () => {
-			setPosition();
-			loopHandler = window.requestAnimationFrame(loop);
-		};
-
-		loop();
+		if (props.showing) startLoop();
 	});
 });
 
 onUnmounted(() => {
-	window.cancelAnimationFrame(loopHandler);
+	unmounted = true;
+	stopLoop();
 });
 </script>
 

--- a/packages/frontend/src/directives/tooltip.ts
+++ b/packages/frontend/src/directives/tooltip.ts
@@ -52,6 +52,21 @@ export default {
 			if (self.text == null) return;
 
 			const showing = ref(true);
+
+			// popupのマウントは非同期なので、await後に_closeを設定するとawait中のmouseleaveを取りこぼしてツールチップが閉じなくなる
+			self._close = () => {
+				showing.value = false;
+			};
+
+			// 表示中に対象要素がDOMから消えた場合(タイムラインのノート再利用など)、mouseleaveが発火しないため自前で閉じる
+			self.checkTimer = window.setInterval(() => {
+				if (!window.document.body.contains(el)) {
+					window.clearTimeout(self.showTimer);
+					window.clearTimeout(self.hideTimer);
+					self.close();
+				}
+			}, 1000);
+
 			await popup(defineAsyncComponent(() => import('@/components/MkTooltip.vue')), {
 				showing,
 				text: self.text,
@@ -59,10 +74,6 @@ export default {
 				direction: binding.modifiers.left ? 'left' : binding.modifiers.right ? 'right' : binding.modifiers.top ? 'top' : binding.modifiers.bottom ? 'bottom' : 'top',
 				targetElement: el,
 			}, {}, 'closed');
-
-			self._close = () => {
-				showing.value = false;
-			};
 		};
 
 		el.addEventListener('selectstart', ev => {
@@ -102,6 +113,9 @@ export default {
 
 	unmounted(el, binding, vn) {
 		const self = el._tooltipDirective_;
-		window.clearInterval(self.checkTimer);
+		// 表示中(または表示待ち)のままアンマウントされた場合に閉じないと、ツールチップが永久にDOMに残る
+		window.clearTimeout(self.showTimer);
+		window.clearTimeout(self.hideTimer);
+		self.close();
 	},
 } as Directive;

--- a/packages/frontend/src/widgets/WidgetCalendar.vue
+++ b/packages/frontend/src/widgets/WidgetCalendar.vue
@@ -99,9 +99,10 @@ const tick = () => {
 	const yearNumer = now.getTime() - new Date(ny, 0, 1).getTime();
 	const yearDenom = new Date(ny + 1, 0, 1).getTime() - new Date(ny, 0, 1).getTime();
 
-	dayP.value = dayNumer / dayDenom * 100;
-	monthP.value = monthNumer / monthDenom * 100;
-	yearP.value = yearNumer / yearDenom * 100;
+	// 表示精度(小数第1位)より細かく毎秒値を変えると、メーターのwidth transitionが毎秒再始動してlayout/paintが走り続けるため丸める
+	dayP.value = Math.round(dayNumer / dayDenom * 1000) / 10;
+	monthP.value = Math.round(monthNumer / monthDenom * 1000) / 10;
+	yearP.value = Math.round(yearNumer / yearDenom * 1000) / 10;
 
 	isHoliday.value = now.getDay() === 0 || now.getDay() === 6;
 };


### PR DESCRIPTION
## 문제

클라이언트가 유휴 상태에서도 CPU 11~20%, 메모리 160~210MB를 점유하며 세션이 길수록 악화됨 (Firefox에서 특히 심각).

## 원인

라이브 인스턴스 계측으로 확인:

1. `MkTooltip`/`MkSkebStatusPopup`이 마운트~언마운트 내내 60fps rAF 루프로 앵커 위치를 추적. 숨겨진 상태(v-show=false)에서도 돌고, `onMounted → nextTick` 안에서 루프를 시작해 언마운트 후 루프가 시작되는 고아 루프 경합도 존재.
2. `v-tooltip` 디렉티브의 `unmounted` 훅이 툴팁을 닫지 않음. 타임라인 스트리밍으로 노트가 재활용되며 커서 아래 앵커가 사라지면 showing=true인 팝업이 영구 잔존 → rAF 루프 + 컴포넌트 트리 누적.
3. `show()`가 `await popup()` 이후에 `_close`를 설정해, 청크 로딩 중 mouseleave가 발생하면 닫기가 유실.

실측: 웰컴 페이지에서 상호작용 없이 수 초 만에 rAF 루프 3개 누수(초당 179회). 로그인 타임라인에서도 커서를 타임라인 위에 둔 채 방치 시 동일 시그니처 재현(고아 루프 3개, DOM 툴팁 0개). 신규 세션 유휴 상태는 깨끗(rAF 0, longtask 0) → 증상은 누적형 누수와 부합.

## 수정

- `MkTooltip.vue`·`MkSkebStatusPopup.vue`: rAF 루프를 `showing`일 때만 가동(watch로 시작/중지), unmounted 플래그로 언마운트 후 루프 시작 차단
- `directives/tooltip.ts`: `_close`를 `await popup()` 이전에 설정, 표시 중 앵커가 DOM에서 사라지면 1초 간격 체크로 자동 닫기, `unmounted` 훅에서 타이머 정리 + `close()` 호출
- `WidgetCalendar.vue`: 매초 부동소수 정밀도로 게이지 width를 갱신해 `transition: width .3s`가 매초 3개씩 재시작되던 것을 표시 정밀도(소수 1자리) 반올림으로 제거 — 표시값이 실제 바뀔 때만 갱신

## 검증

- 변경 파일 ESLint 에러 0 (경고는 기존 베이스라인)
- vue-tsc 변경 파일 관련 신규 오류 없음
- `pnpm --filter frontend build` 통과