### PR TITLE
fix(backend): remove duplicate inline boot script that breaks first visit

### DIFF
--- a/packages/backend/src/server/web/views/base.pug
+++ b/packages/backend/src/server/web/views/base.pug
@@ -83,10 +83,6 @@ html
 
 		| !{extraHead}
 
-
-		script
-			include ../boot.js
-
 	body
 		noscript: p
 			| JavaScriptを有効にしてください


### PR DESCRIPTION
## 문제

localStorage에 `locale`이 없는 첫 방문자는 항상 `ReferenceError: LANGS is not defined`로 부트가 실패해 "Failed to initialize Misskey" 에러 화면을 보게 됨. 재방문 시에는 외부 boot 스크립트가 저장해둔 locale 덕에 정상 동작하므로 기존 사용자에게는 보이지 않는 버그.

## 원인

base.pug가 boot 스크립트를 두 번 포함:

- 82행: `/assets/boot.<version>.js` — 빌드 시(scripts/build-assets.mjs) `LANGS`가 실제 언어 배열로 치환된 정상 로더
- 87–88행: `include ../boot.js` — swc가 그대로 복사한 원본이 인라인으로 들어가 `LANGS` 식별자가 치환되지 않은 채 실행됨

locale이 이미 저장돼 있으면 인라인 쪽이 LANGS 분기를 건너뛰어 문제가 드러나지 않지만, 첫 방문에는 외부 스크립트의 locale fetch가 끝나기 전에 인라인이 실행돼 ReferenceError → 에러 화면.

upstream(MisskeyIO/misskey main)도 동일하게 깨져 있음. 별도 브랜치의 커밋 6a83205581(bootスクリプトの二重読み込みを防止)이 같은 취지로 인라인을 제거했으나 병합 계보에 포함되지 않았음.

## 수정

base.pug의 인라인 boot include 제거. 외부 `/assets/boot.<version>.js`가 유일한 로더가 됨 (라이브에서 LANGS 치환 정상 서빙 확인). embed 페이지(base-embed.pug)의 boot.embed.js는 LANGS를 사용하지 않으므로 영향 없음.